### PR TITLE
feat: Do not create delivery note automatically (csf_tz feature) if Inpatient record sales invoice

### DIFF
--- a/hms_tz/nhif/api/sales_invoice.py
+++ b/hms_tz/nhif/api/sales_invoice.py
@@ -22,6 +22,15 @@ def validate(doc, method):
                 ).format(item.item_name)
             )
     update_dimensions(doc)
+    validate_create_delivery_note(doc)
+
+
+def validate_create_delivery_note(doc):
+    if not doc.patient:
+        return
+    inpatient_record = frappe.get_value("Patient", doc.patient, "inpatient_record")
+    if inpatient_record:
+        doc.enabled_auto_create_delivery_notes = 0
 
 
 @frappe.whitelist()


### PR DESCRIPTION
We have changed code for inpatient cash patient to automatically create LRPMT (hms_tz feature), like insurance even if it is cash due to business workflow requirements. And when the Sales Invoice is created we do not want it to create the delivery notes (csf_tz feature). Currently we are getting drug prescriptions doubled because it creates 2nd time.
Can you find a way to avoid creating delivery notes for such types of Sales Invoices where patient has inpatient_record created so that the auto delivery note does not get created?