### PR TITLE
fix: check if patient file pdf for claim number is already in file doctype, convert it to base64 and use it, insteady of generating pdf again

### DIFF
--- a/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
+++ b/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
@@ -728,12 +728,12 @@ def get_item_refcode(item_code):
 
 
 def generate_pdf(doc):
-    doc_name = doc.name
-    file_list = frappe.get_all("File", filters={"attached_to_name": doc_name})
+    file_list = frappe.get_all("File", filters={"attached_to_doctype": "NHIF Patient Claim", "file_name": str(doc.name + ".pdf")})
     if file_list:
-        file_doc = frappe.get_doc("File", file_list[0].name)
-        pdf = file_doc.get_content()
-        return to_base64(pdf)
+        patientfile = frappe.get_doc("File", file_list[0].name)
+        if patientfile:
+            pdf = patientfile.get_content()
+            return to_base64(pdf)
 
     data_list = []
     data = doc.patient_encounters
@@ -751,16 +751,16 @@ def generate_pdf(doc):
     else:
         print_format = "Patient File"
 
-    pdf = download_multi_pdf(doctype, doc_name, print_format=print_format, no_letterhead=1)
+    pdf = download_multi_pdf(doctype, doc.name, print_format=print_format, no_letterhead=1)
     if pdf:
         ret = frappe.get_doc(
             {
                 "doctype": "File",
                 "attached_to_doctype": "NHIF Patient Claim",
-                "attached_to_name": doc_name,
+                "attached_to_name": doc.name,
                 "folder": "Home/Attachments",
-                "file_name": doc_name + ".pdf",
-                "file_url": "/private/files/" + doc_name + ".pdf",
+                "file_name": doc.name + ".pdf",
+                "file_url": "/private/files/" + doc.name + ".pdf",
                 "content": pdf,
                 "is_private": 1,
             }
@@ -802,6 +802,11 @@ def read_multi_pdf(output):
 
 
 def get_claim_pdf_file(doc):
+    file_list = frappe.get_all("File", filters={"attached_to_doctype": "NHIF Patient Claim", "file_name": str(doc.name + "-claim.pdf")})
+    if file_list:
+        for file in file_list:
+            frappe.delete_doc("File", file.name, ignore_permissions=True)
+    
     doctype = doc.doctype
     docname = doc.name
     default_print_format = frappe.db.get_value(

--- a/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
+++ b/hms_tz/nhif/doctype/nhif_patient_claim/nhif_patient_claim.py
@@ -730,8 +730,10 @@ def get_item_refcode(item_code):
 def generate_pdf(doc):
     doc_name = doc.name
     file_list = frappe.get_all("File", filters={"attached_to_name": doc_name})
-    for file in file_list:
-        frappe.delete_doc("File", file.name, ignore_permissions=True)
+    if file_list:
+        file_doc = frappe.get_doc("File", file_list[0].name)
+        pdf = file_doc.get_content()
+        return to_base64(pdf)
 
     data_list = []
     data = doc.patient_encounters


### PR DESCRIPTION
…ctype, convert it to base64 and use it, insteady of generating pdf again